### PR TITLE
fix: update for improved handling of optional values

### DIFF
--- a/src/components/Footer/EditModeFooter.tsx
+++ b/src/components/Footer/EditModeFooter.tsx
@@ -7,7 +7,7 @@ interface IEditModeFooterProps {
   onClose: () => void;
   title: string;
   onSave: (value?: string) => void;
-  onSaveText?: string;
+  onSaveText?: string; // FUTURE: rename to saveButtonText, but need to discuss with team
   value?: string;
   disabled?: boolean;
 }

--- a/src/pages/EditUser/index.tsx
+++ b/src/pages/EditUser/index.tsx
@@ -101,7 +101,7 @@ const EditUserPage: React.FC = () => {
       placeholder: t`Add URL`,
       edittingFieldValue: newUserInfo.socialLinks?.[SocialLinkType.CUSTOMIZED],
       onFieldValueSet: (value: string | undefined) => {
-        if (value) {
+        if (value !== undefined) {
           setSocialLink(SocialLinkType.CUSTOMIZED, value);
         } else {
           console.log('value is undefined');
@@ -120,10 +120,12 @@ const EditUserPage: React.FC = () => {
         return extractUsernameFromUrl(SocialLinkType.INSTAGRAM, value) ?? '';
       },
       onFieldValueSet: (value: string | undefined) => {
-        if (value) {
+        if (value !== undefined) {
           setSocialLink(
             SocialLinkType.INSTAGRAM,
-            `${socialLinkStarterMap[SocialLinkType.INSTAGRAM]}${value}`
+            value.length > 0
+              ? `${socialLinkStarterMap[SocialLinkType.INSTAGRAM]}${value}`
+              : ''
           );
         } else {
           console.log('value is undefined');
@@ -142,10 +144,12 @@ const EditUserPage: React.FC = () => {
         return extractUsernameFromUrl(SocialLinkType.YOUTUBE, value) ?? '';
       },
       onFieldValueSet: (value: string | undefined) => {
-        if (value) {
+        if (value !== undefined) {
           setSocialLink(
             SocialLinkType.YOUTUBE,
-            `${socialLinkStarterMap[SocialLinkType.YOUTUBE]}${value}`
+            value.length > 0
+              ? `${socialLinkStarterMap[SocialLinkType.YOUTUBE]}${value}`
+              : ''
           );
         } else {
           console.log('value is undefined');
@@ -164,10 +168,12 @@ const EditUserPage: React.FC = () => {
         return extractUsernameFromUrl(SocialLinkType.TIKTOK, value) ?? '';
       },
       onFieldValueSet: (value: string | undefined) => {
-        if (value) {
+        if (value !== undefined) {
           setSocialLink(
             SocialLinkType.TIKTOK,
-            `${socialLinkStarterMap[SocialLinkType.TIKTOK]}${value}`
+            value.length > 0
+              ? `${socialLinkStarterMap[SocialLinkType.TIKTOK]}${value}`
+              : ''
           );
         } else {
           console.log('value is undefined');
@@ -186,10 +192,12 @@ const EditUserPage: React.FC = () => {
         return extractUsernameFromUrl(SocialLinkType.THREADS, value) ?? '';
       },
       onFieldValueSet: (value: string | undefined) => {
-        if (value) {
+        if (value !== undefined) {
           setSocialLink(
             SocialLinkType.THREADS,
-            `${socialLinkStarterMap[SocialLinkType.THREADS]}${value}`
+            value.length > 0
+              ? `${socialLinkStarterMap[SocialLinkType.THREADS]}${value}`
+              : ''
           );
         } else {
           console.log('value is undefined');
@@ -208,10 +216,12 @@ const EditUserPage: React.FC = () => {
         return extractUsernameFromUrl(SocialLinkType.LINKEDIN, value) ?? '';
       },
       onFieldValueSet: (value: string | undefined) => {
-        if (value) {
+        if (value !== undefined) {
           setSocialLink(
             SocialLinkType.LINKEDIN,
-            `${socialLinkStarterMap[SocialLinkType.LINKEDIN]}${value}`
+            value.length > 0
+              ? `${socialLinkStarterMap[SocialLinkType.LINKEDIN]}${value}`
+              : ''
           );
         } else {
           console.log('value is undefined');


### PR DESCRIPTION
## Description

- Added a comment in EditModeFooter to indicate a future renaming of the onSaveText prop for clarity.
- Updated EditUserPage to check for undefined values instead of falsy values in onFieldValueSet functions, enhancing the handling of optional social link inputs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Affected Pages

- [x] Edit Profile Page

## Related Project Task (Linear)

https://linear.app/poklist/issue/PD-210/edit-profile-page-social-links-not-removable

## Checklist

- [ ] I have manually tested this locally to ensure functionality and stability
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation, or my changes do not require documentation updates
- [ ] My PR has a clear title and description
