### PR TITLE
fix: enhance ImageCropper zoom handling and slider integration

### DIFF
--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ value, onChange, className, ...props }, ref) => (
+>(({ className, ...props }, ref) => (
   <form>
     <SliderPrimitive.Root
       ref={ref}


### PR DESCRIPTION
## Description
- Added a ref to throttle zoom updates in the ImageCropper component, improving performance during pinch/drag interactions.
- Refactored zoom change handling to separate functions for cropper and slider, ensuring immediate updates from the slider while maintaining throttled updates from the cropper.
- Updated the Slider component to remove unnecessary props, streamlining its usage.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Affected Pages

## Related Project Task (Linear)

https://linear.app/poklist/issue/PD-199/imagecropper-slider-issue

## Checklist

- [x] I have manually tested this locally to ensure functionality and stability
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation, or my changes do not require documentation updates
- [x] My PR has a clear title and description
