### PR TITLE
fix: change list/idea cover img, username validate timing, preload homepage img

### DIFF
--- a/src/components/FakePage/EditFieldFakePage.tsx
+++ b/src/components/FakePage/EditFieldFakePage.tsx
@@ -119,6 +119,18 @@ const TextInput: React.FC<ITextInputProps> = ({
     setOffset({ start, end });
   };
 
+  const handleCompositionEnd = (
+    e: React.CompositionEvent<HTMLTextAreaElement>
+  ) => {
+    setIsComposing(false);
+
+    const newValue = e.currentTarget.value;
+    if (validator === undefined || validator(newValue)) {
+      setFieldValue(newValue);
+      onChange(newValue);
+    }
+  };
+
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (isComposing) {
       setNeedUpdateCursor(true);
@@ -168,6 +180,7 @@ const TextInput: React.FC<ITextInputProps> = ({
         className="w-full border-0"
         placeholder={placeholderText}
         onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
       />
       {characterLimit && (
         <p className="self-end text-black-gray-03">

--- a/src/components/FakePage/EditFieldFakePage.tsx
+++ b/src/components/FakePage/EditFieldFakePage.tsx
@@ -69,6 +69,7 @@ export const EditFieldFakePageComponent: React.FC<IEditFieldConfig> = ({
               onFieldValueSet(fieldValue);
               closeFakePage();
             }
+            return;
           }}
           value={fieldValue}
         />

--- a/src/components/FakePage/EditFieldFakePage.tsx
+++ b/src/components/FakePage/EditFieldFakePage.tsx
@@ -69,7 +69,6 @@ export const EditFieldFakePageComponent: React.FC<IEditFieldConfig> = ({
               onFieldValueSet(fieldValue);
               closeFakePage();
             }
-            return;
           }}
           value={fieldValue}
         />
@@ -110,6 +109,22 @@ const TextInput: React.FC<ITextInputProps> = ({
     onChange(newValue);
   };
 
+  const handleBeforeInput = (
+    e: React.FormEvent<HTMLTextAreaElement> & { data: string }
+  ) => {
+    const textarea = e.currentTarget;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const newValue =
+      fieldValue?.slice(0, start) + e.data + fieldValue?.slice(end);
+    const passed = validator === undefined || validator(newValue);
+
+    if (!passed) {
+      e.preventDefault();
+      return;
+    }
+  };
+
   return (
     <>
       <Textarea
@@ -117,6 +132,7 @@ const TextInput: React.FC<ITextInputProps> = ({
         value={fieldValue}
         maxLength={characterLimit}
         onChange={handleInput}
+        onBeforeInput={handleBeforeInput}
         className="w-full border-0"
         placeholder={placeholderText}
       />

--- a/src/pages/Idea/Components/DeleteButton/index.tsx
+++ b/src/pages/Idea/Components/DeleteButton/index.tsx
@@ -30,7 +30,10 @@ export const DeleteButton: React.FC<IDeleteButtonProps> = ({
         subHeader={<Trans>Once deleted, this idea cannot be recovered!</Trans>}
         startFooter={
           <Button
-            onClick={() => deleteCallback()}
+            onClick={() => {
+              deleteCallback();
+              closeDrawer();
+            }}
             variant={ButtonVariant.WARNING}
             shape={ButtonShape.ROUNDED_5PX}
           >

--- a/src/pages/Idea/Components/Form/index.tsx
+++ b/src/pages/Idea/Components/Form/index.tsx
@@ -277,7 +277,7 @@ const IdeaFormComponent: React.FC<IIdeaFormProps> = ({
                 file={field.value}
                 callback={onOpenFakePage}
                 onRemove={() => {
-                  ideaForm.setValue('coverImage', null);
+                  ideaForm.setValue('coverImage', '');
                 }}
               />
             )}

--- a/src/pages/Lists/Components/Form/index.tsx
+++ b/src/pages/Lists/Components/Form/index.tsx
@@ -322,7 +322,7 @@ const ListForm: React.FC<IListFormProps> = ({
                 file={field.value}
                 callback={onOpenFakePage}
                 onRemove={() => {
-                  listForm.setValue('coverImage', null);
+                  listForm.setValue('coverImage', '');
                 }}
               />
             )}


### PR DESCRIPTION
## Description
- fix: when pressing the confirm delete button, close the drawer
- fix: need to send the empty string to remove image, not null
- fix: validate when submitting and typing complete, not when typing
- fix: preload homepage img

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Affected Pages
- ListViewEditPage
- ProfileAccountPage
- OfficalPage

## Related Project Task (Linear)
- https://linear.app/poklist/issue/PD-200/用戶帳號選項輸入內容無法顯示
- https://linear.app/poklist/issue/PD-197/刪除一靈感後再進入另一靈感編輯頁跳出刪除靈感drawer
- https://linear.app/poklist/issue/PD-193/同樣路徑，封面靈感圖片-刪除失效

## Checklist

- [X] I have manually tested this locally to ensure functionality and stability
- [X] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation, or my changes do not require documentation updates
- [X] My PR has a clear title and description
