### PR TITLE
fix: focus title input

### DIFF
--- a/src/pages/Idea/Components/Form/index.tsx
+++ b/src/pages/Idea/Components/Form/index.tsx
@@ -63,7 +63,7 @@ const IdeaFormComponent: React.FC<IIdeaFormProps> = ({
         if (value !== undefined && value !== null) {
           onCoverImageChange(value);
         } else {
-          console.log('value is undefined');
+          console.error('value is undefined');
         }
       },
     });
@@ -79,6 +79,10 @@ const IdeaFormComponent: React.FC<IIdeaFormProps> = ({
       coverImage: previousIdeaInfo?.coverImage,
     },
   });
+
+  useEffect(() => {
+    ideaForm.setFocus('title');
+  }, [ideaForm.setFocus]);
 
   const onInputChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -202,12 +206,7 @@ const IdeaFormComponent: React.FC<IIdeaFormProps> = ({
         onSubmit={() => void ideaForm.handleSubmit(onSubmit, onSubmitFailed)()}
         className="mx-4 mt-4 flex flex-1 flex-col gap-6 md:max-w-mobile-max"
       >
-        <div
-          className={cn(`flex items-center font-extrabold`, {
-            'before:h-8 before:w-0.5 before:bg-black-text-01':
-              ideaForm.watch('title') === '',
-          })}
-        >
+        <div className="flex items-center font-extrabold">
           <Input
             placeholder={t`This is the title of your idea`}
             className="relative border-none px-0 text-h1 placeholder:text-h1"

--- a/src/pages/Lists/Components/Form/index.tsx
+++ b/src/pages/Lists/Components/Form/index.tsx
@@ -97,6 +97,10 @@ const ListForm: React.FC<IListFormProps> = ({
     },
   });
 
+  useEffect(() => {
+    listForm.setFocus('title');
+  }, [listForm.setFocus]);
+
   const onInputChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
@@ -249,12 +253,7 @@ const ListForm: React.FC<IListFormProps> = ({
         }}
         className="mx-4 mt-6 flex flex-1 flex-col gap-6 px-4 md:max-w-mobile-max"
       >
-        <div
-          className={cn(`flex items-center justify-center font-extrabold`, {
-            'before:h-8 before:w-0.5 before:bg-black-text-01':
-              listForm.watch('title') === '',
-          })}
-        >
+        <div className="flex items-center justify-center font-extrabold">
           <Input
             placeholder={t`This is the title of your list`}
             className="relative w-min border-none text-h1 placeholder:text-h1"


### PR DESCRIPTION

## Description

Automatically focuses on the title input field when the idea form is rendered

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Affected Pages

- [x] Create & Edit Idea Page
- [x] Create & Edit List Page

## Related Project Task (Linear)

https://linear.app/relistspace/issue/PD-264/創單創靈感無自動鍵盤和閃爍cursor

## Checklist

- [x] I have manually tested this locally to ensure functionality and stability
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have updated the documentation, or my changes do not require documentation updates
- [x] My PR has a clear title and description
